### PR TITLE
Reduce spacing and gaps across website sections

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -30,8 +30,8 @@
         .contact-grid {
             display: grid;
             grid-template-columns: 1fr 1fr;
-            gap: 4rem;
-            margin: 3rem 0;
+            gap: 2rem;
+            margin: 2rem 0;
         }
         
         .contact-info {
@@ -45,8 +45,8 @@
             display: flex;
             align-items: flex-start;
             gap: 1rem;
-            margin-bottom: 2rem;
-            padding-bottom: 2rem;
+            margin-bottom: 1.5rem;
+            padding-bottom: 1.5rem;
             border-bottom: 1px solid var(--border-color);
         }
         

--- a/features.html
+++ b/features.html
@@ -30,9 +30,9 @@
         .feature-detail {
             display: grid;
             grid-template-columns: 1fr 1fr;
-            gap: 4rem;
+            gap: 2rem;
             align-items: center;
-            margin: 4rem 0;
+            margin: 2rem 0;
         }
         
         .feature-detail:nth-child(even) {

--- a/styles.css
+++ b/styles.css
@@ -3456,8 +3456,8 @@ p {
   background: var(--gradient-section);
   text-align: center;
   backdrop-filter: blur(20px);
-  padding: 8rem 0;
-  margin: 4rem 0;
+  padding: 4rem 0;
+  margin: 2rem 0;
   position: relative;
   border-top: 1px solid rgba(139, 92, 246, 0.2);
   border-bottom: 1px solid rgba(139, 92, 246, 0.2);
@@ -4430,7 +4430,7 @@ p {
 }
 
 .requirement-card li::before {
-  content: '•';
+  content: '��';
   color: var(--color-accent);
   position: absolute;
   left: 0;

--- a/styles.css
+++ b/styles.css
@@ -3509,11 +3509,11 @@ p {
 .footer {
   background: linear-gradient(135deg, rgba(15, 15, 25, 0.95) 0%, rgba(30, 40, 60, 0.9) 100%);
   border-top: 1px solid rgba(255, 255, 255, 0.08);
-  padding: 5rem 0 2.5rem;
+  padding: 3rem 0 2rem;
   backdrop-filter: blur(20px);
   position: relative;
   overflow: hidden;
-  margin-top: 3rem;
+  margin-top: 2rem;
 }
 
 .footer::before {

--- a/styles.css
+++ b/styles.css
@@ -1843,7 +1843,7 @@ p {
   align-items: center;
   background: linear-gradient(135deg, rgba(79, 70, 229, 0.08) 0%, rgba(139, 92, 246, 0.08) 100%);
   margin-top: 100px;
-  padding: 4rem 0;
+  padding: 2rem 0;
   position: relative;
 }
 
@@ -1890,7 +1890,7 @@ p {
   background: var(--glass-bg);
   border: 1px solid var(--glass-border);
   border-radius: var(--border-radius);
-  padding: 2.5rem;
+  padding: 2rem;
   text-align: center;
   transition: all 0.4s cubic-bezier(0.16, 1, 0.3, 1);
   position: relative;
@@ -2035,10 +2035,10 @@ p {
 
 /* Utility classes */
 .text-center { text-align: center; }
-.mb-3 { margin-bottom: 3rem; }
-.mb-4 { margin-bottom: 4rem; }
-.mt-3 { margin-top: 3rem; }
-.mt-4 { margin-top: 4rem; }
+.mb-3 { margin-bottom: 2rem; }
+.mb-4 { margin-bottom: 2.5rem; }
+.mt-3 { margin-top: 2rem; }
+.mt-4 { margin-top: 2.5rem; }
 
 /* Requirements and installation sections */
 .requirements-section {

--- a/styles.css
+++ b/styles.css
@@ -645,7 +645,7 @@ p {
 }
 
 .section {
-  padding: 8rem 0;
+  padding: 4rem 0;
   position: relative;
 }
 
@@ -722,7 +722,7 @@ p {
 .hero-buttons {
   display: flex;
   gap: 1rem;
-  margin-bottom: 3rem;
+  margin-bottom: 2rem;
   justify-content: center;
   flex-wrap: wrap;
 }
@@ -730,7 +730,7 @@ p {
 .hero-stats {
   display: flex;
   gap: 3rem;
-  margin-top: 3rem;
+  margin-top: 2rem;
   justify-content: center;
   flex-wrap: wrap;
 }
@@ -755,7 +755,7 @@ p {
   display: flex;
   justify-content: center;
   align-items: center;
-  margin-top: 2rem;
+  margin-top: 1.5rem;
 }
 
 .hero-card {
@@ -814,7 +814,7 @@ p {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
   gap: 2rem;
-  margin-top: 3rem;
+  margin-top: 2rem;
 }
 
 .feature-card {
@@ -912,7 +912,7 @@ p {
   display: flex;
   justify-content: center;
   gap: 3rem;
-  margin-top: 3rem;
+  margin-top: 2rem;
   flex-wrap: wrap;
 }
 
@@ -952,7 +952,7 @@ p {
 /* Enhanced VMS Section with Dynamic Animations */
 .vms-section {
   position: relative;
-  padding: 8rem 0;
+  padding: 4rem 0;
   background: linear-gradient(
     135deg,
     rgba(10, 10, 10, 0.98) 0%,
@@ -1059,7 +1059,7 @@ p {
 /* VMS Header Styling */
 .vms-header {
   text-align: center;
-  margin-bottom: 6rem;
+  margin-bottom: 3rem;
   position: relative;
 }
 
@@ -1162,7 +1162,7 @@ p {
 
 /* Platform Guarantee Section */
 .vms-platform-guarantee {
-  margin-bottom: 6rem;
+  margin-bottom: 3rem;
 }
 
 .platform-guarantee-container {
@@ -1343,7 +1343,7 @@ p {
 
 /* VMS Benefits Grid - Single Row Layout */
 .vms-benefits-wrapper {
-  margin-bottom: 6rem;
+  margin-bottom: 3rem;
   padding: 0 1rem;
 }
 

--- a/styles.css
+++ b/styles.css
@@ -1643,7 +1643,7 @@ p {
 /* VMS Matters Section Styles for Contact/Support/Download pages */
 .vms-matters-section {
   position: relative;
-  padding: 6rem 0;
+  padding: 3rem 0;
   background: linear-gradient(
     135deg,
     rgba(10, 10, 10, 0.98) 0%,
@@ -1662,7 +1662,7 @@ p {
   font-size: var(--fluid-18-20);
   color: var(--color-text-secondary);
   max-width: 700px;
-  margin: 0 auto 3rem;
+  margin: 0 auto 2rem;
   line-height: 1.7;
   font-weight: 400;
   text-align: center;
@@ -1672,8 +1672,8 @@ p {
   background: linear-gradient(135deg, rgba(34, 197, 94, 0.1) 0%, rgba(16, 185, 129, 0.08) 100%);
   border: 1px solid rgba(34, 197, 94, 0.3);
   border-radius: 20px;
-  padding: 2.5rem;
-  margin: 3rem auto;
+  padding: 2rem;
+  margin: 2rem auto;
   max-width: 900px;
   display: flex;
   align-items: center;
@@ -1718,10 +1718,8 @@ p {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
   gap: 2rem;
-  margin: 3rem 0;
+  margin: 2rem auto;
   max-width: 1200px;
-  margin-left: auto;
-  margin-right: auto;
 }
 
 .vms-feature-card {
@@ -1805,7 +1803,7 @@ p {
 
 .vms-cta-container {
   text-align: center;
-  margin-top: 3rem;
+  margin-top: 2rem;
 }
 
 .vms-cta-btn {
@@ -2925,7 +2923,7 @@ p {
 /* Dynamic Marketplace Showcase Section */
 .marketplace-showcase-section {
   position: relative;
-  padding: 8rem 0;
+  padding: 4rem 0;
   background: linear-gradient(
     135deg,
     rgba(15, 15, 25, 0.98) 0%,

--- a/styles.css
+++ b/styles.css
@@ -1883,7 +1883,7 @@ p {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
   gap: 2rem;
-  margin: 3rem 0;
+  margin: 2rem 0;
 }
 
 .download-card {
@@ -2050,7 +2050,7 @@ p {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
   gap: 2rem;
-  margin: 3rem 0;
+  margin: 2rem 0;
 }
 
 .requirement-card {
@@ -2117,7 +2117,7 @@ p {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
   gap: 2rem;
-  margin: 3rem 0;
+  margin: 2rem 0;
 }
 
 .install-step {
@@ -2160,7 +2160,7 @@ p {
   grid-template-columns: repeat(2, 1fr);
   gap: 2rem;
   max-width: 800px;
-  margin: 3rem auto;
+  margin: 2rem auto;
 }
 
 /* Contact Page Specific Styles */
@@ -2176,8 +2176,8 @@ p {
 .contact-grid {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 4rem;
-  margin: 3rem 0;
+  gap: 2rem;
+  margin: 2rem 0;
 }
 
 .contact-info {
@@ -2297,7 +2297,7 @@ p {
   background: var(--secondary-bg);
   border-radius: var(--border-radius);
   padding: 2rem;
-  margin: 3rem 0;
+  margin: 2rem 0;
   backdrop-filter: blur(20px);
 }
 
@@ -2516,7 +2516,7 @@ p {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
   gap: 2rem;
-  margin: 3rem 0;
+  margin: 2rem 0;
 }
 
 .support-card {

--- a/styles.css
+++ b/styles.css
@@ -3530,8 +3530,8 @@ p {
 .footer-content {
   display: grid;
   grid-template-columns: 2fr 1fr 1fr;
-  gap: 4rem;
-  margin-bottom: 3.5rem;
+  gap: 2rem;
+  margin-bottom: 2rem;
   position: relative;
   z-index: 2;
 }


### PR DESCRIPTION
## Purpose
The user requested to remove excessive gaps and empty sections throughout the entire website to create a more compact and visually cohesive layout.

## Code changes
- **Section padding**: Reduced main section padding from 8rem to 4rem
- **Margin adjustments**: Decreased various margin values from 3-4rem to 2-2.5rem across components
- **Grid gaps**: Reduced grid gaps from 4rem to 2rem in contact and features pages
- **Hero section**: Compressed hero button and stats margins from 3rem to 2rem
- **VMS sections**: Reduced header, benefits, and platform guarantee margins from 6rem to 3rem
- **Footer**: Decreased footer padding and content gaps for tighter spacing
- **Utility classes**: Updated margin utility classes to use smaller values
- **Component spacing**: Adjusted padding and margins in cards, grids, and containers throughout the site

These changes create a more compact layout while maintaining visual hierarchy and readability.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 9`

🔗 [Edit in Builder.io](https://builder.io/app/projects/dc83a0bee11c4e1e851e1225b0a5871f/swoosh-forge)

👀 [Preview Link](https://dc83a0bee11c4e1e851e1225b0a5871f-swoosh-forge.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>dc83a0bee11c4e1e851e1225b0a5871f</projectId>-->
<!--<branchName>swoosh-forge</branchName>-->